### PR TITLE
[Documentation] Nvim lsp module name fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ lua << END
 local lsp_status = require('lsp-status')
 lsp_status.register_progress()
 
-local nvim_lsp = require('nvim-lsp')
+local nvim_lsp = require('nvim_lsp')
 
 -- Some arbitrary servers
 nvim_lsp.clangd.setup({

--- a/doc/lsp-status.txt
+++ b/doc/lsp-status.txt
@@ -42,7 +42,7 @@ example:>
   local lsp_status = require('lsp-status')
   lsp_status.register_progress()
 
-  local nvim_lsp = require('nvim-lsp')
+  local nvim_lsp = require('nvim_lsp')
 
   -- Some arbitrary servers
   nvim_lsp.clangd.setup({


### PR DESCRIPTION
The Nvim LSP module is called `nvim_lsp`, the previous `nvim-lsp` would result in many errors.