### PR TITLE
Fix deprecation warning on buf_diagnostics_count

### DIFF
--- a/lua/lsp-status/diagnostics.lua
+++ b/lua/lsp-status/diagnostics.lua
@@ -9,7 +9,7 @@ local function get_all_diagnostics()
   }
 
   for k, level in pairs(levels) do
-    result[k] = vim.lsp.util.buf_diagnostics_count(level)
+    result[k] = vim.lsp.diagnostic.get_count(level)
   end
 
   return result


### PR DESCRIPTION
This commit introduced changes in lua API for LSP.
We are now getting a deprecation warning for `buf_diagnostics_count` on start.

See this commit for more info: https://github.com/neovim/neovim/commit/f75be5e9d510d5369c572cf98e78d9480df3b0bb