### PR TITLE
Potentially fix #24 by checking the result type before processing

### DIFF
--- a/lua/lsp-status/current_function.lua
+++ b/lua/lsp-status/current_function.lua
@@ -11,6 +11,10 @@ end
 -- Find current function context
 local function current_function_callback(_, _, result, _, _)
   vim.b.lsp_current_function = ''
+  if type(result) ~= table then
+    return
+  end
+
   local function_symbols = util.filter(util.extract_symbols(result),
     function(_, v)
       return v.kind == 'Class' or v.kind == 'Function' or v.kind == 'Method'


### PR DESCRIPTION
`extract_symbols` passes its argument to `ipairs`, so we check if `result` (passed to `extract_symbols`) is a table before calling `extract_symbols`. This should have the effect of only updating the current function when we've gotten a valid value from the server.