### PR TITLE
make indicator-separator configurable

### DIFF
--- a/lua/lsp-status.lua
+++ b/lua/lsp-status.lua
@@ -2,6 +2,7 @@ local _config = {}
 local default_config = {
   kind_labels = {},
   current_function = true,
+  indicator_separator = ' ',
   indicator_errors = '',
   indicator_warnings = '',
   indicator_info = '🛈',

--- a/lua/lsp-status/statusline.lua
+++ b/lua/lsp-status/statusline.lua
@@ -21,25 +21,25 @@ local function statusline_lsp()
   local some_diagnostics = false
   local status_parts = {}
   if buf_diagnostics.errors and buf_diagnostics.errors > 0 then
-    table.insert(status_parts, config.indicator_errors .. ' ' .. buf_diagnostics.errors)
+    table.insert(status_parts, config.indicator_errors .. config.indicator_separator .. buf_diagnostics.errors)
     only_hint = false
     some_diagnostics = true
   end
 
   if buf_diagnostics.warnings and buf_diagnostics.warnings > 0 then
-    table.insert(status_parts, config.indicator_warnings .. ' ' .. buf_diagnostics.warnings)
+    table.insert(status_parts, config.indicator_warnings .. config.indicator_separator .. buf_diagnostics.warnings)
     only_hint = false
     some_diagnostics = true
   end
 
   if buf_diagnostics.info and buf_diagnostics.info > 0 then
-    table.insert(status_parts, config.indicator_info .. ' ' .. buf_diagnostics.info)
+    table.insert(status_parts, config.indicator_info .. config.indicator_separator .. buf_diagnostics.info)
     only_hint = false
     some_diagnostics = true
   end
 
   if buf_diagnostics.hints and buf_diagnostics.hints > 0 then
-    table.insert(status_parts, config.indicator_hint .. ' ' .. buf_diagnostics.hints)
+    table.insert(status_parts, config.indicator_hint .. config.indicator_separator .. buf_diagnostics.hints)
     some_diagnostics = true
   end
 


### PR DESCRIPTION
I thought it would be nice to make the separator between the indicator and count configurable (I personally use an empty-string because it makes my statusline a little easier for me to parse).