### PR TITLE
Fix problem with doautocmd and modeline

### DIFF
--- a/lua/lsp-status/current_function.lua
+++ b/lua/lsp-status/current_function.lua
@@ -21,7 +21,7 @@ local function current_function_callback(_, _, result, _, _)
     end)
 
   if not function_symbols or #function_symbols == 0 then
-    vim.api.nvim_command('doautocmd User LspStatusUpdate')
+    vim.api.nvim_command('doautocmd <nomodeline> User LspStatusUpdate')
     return
   end
 
@@ -38,7 +38,7 @@ local function current_function_callback(_, _, result, _, _)
       end
 
       vim.b.lsp_current_function = fn_name
-      vim.api.nvim_command('doautocmd User LspStatusUpdate')
+      vim.api.nvim_command('doautocmd <nomodeline> User LspStatusUpdate')
       return
     end
   end

--- a/lua/lsp-status/extensions/clangd.lua
+++ b/lua/lsp-status/extensions/clangd.lua
@@ -16,7 +16,7 @@ local handlers = {
   ['textDocument/clangd.fileStatus'] = function(_, _, statusMessage, client_id)
     ensure_init(client_id)
     messages[client_id].status = { uri = statusMessage.uri, content = statusMessage.state }
-    vim.api.nvim_command('doautocmd User LspMessageUpdate')
+    vim.api.nvim_command('doautocmd <nomodeline> User LspMessageUpdate')
   end,
 }
 

--- a/lua/lsp-status/extensions/pyls_ms.lua
+++ b/lua/lsp-status/extensions/pyls_ms.lua
@@ -15,7 +15,7 @@ local handlers =  {
   ['python/setStatusBarMessage'] = function(_, _, message, client_id)
     ensure_init(client_id)
     messages[client_id].static_message = { content = message[1] }
-    vim.api.nvim_command('doautocmd User LspMessageUpdate')
+    vim.api.nvim_command('doautocmd <nomodeline> User LspMessageUpdate')
   end,
   ['python/beginProgress'] = function(_, _, _, client_id)
     ensure_init(client_id)
@@ -26,11 +26,11 @@ local handlers =  {
   ['python/reportProgress'] = function(_, _, message, client_id)
     messages[client_id].progress[1].spinner = messages[client_id].progress[1].spinner + 1
     messages[client_id].progress[1].title = message[1]
-    vim.api.nvim_command('doautocmd User LspMessageUpdate')
+    vim.api.nvim_command('doautocmd <nomodeline> User LspMessageUpdate')
   end,
   ['python/endProgress'] = function(_, _, _, client_id)
     messages[client_id].progress[1] = nil
-    vim.api.nvim_command('doautocmd User LspMessageUpdate')
+    vim.api.nvim_command('doautocmd <nomodeline> User LspMessageUpdate')
   end,
 }
 

--- a/lua/lsp-status/messaging.lua
+++ b/lua/lsp-status/messaging.lua
@@ -43,7 +43,7 @@ local function progress_callback(_, _, msg, client_id)
     table.insert(messages[client_id], {content = val, show_once = true, shown = 0})
   end
 
-  vim.api.nvim_command('doautocmd User LspMessageUpdate')
+  vim.api.nvim_command('doautocmd <nomodeline> User LspMessageUpdate')
 end
 
 -- Process messages


### PR DESCRIPTION
This fixes an issue i had trying to integrate lsp-status.nvim into my statusline. Everytime i moved my cursor all my folds were getting closed. I found out that `doautocmd` reloads the `modeline` which caused `foldlevel=0` from my modeline to be run again. Fortunately this can be suppressed using the `<nomodeline>` flag. I replaced every `doautocmd` call with `doautocmd <nomodeline>`.

### Example
Use the following file and command to reproduce: `nvim --clean -u test.vim test.vim`
```vim
" Test {{{
set modeline
au User Test echom 'test'
" }}}

" vim: foldmethod=marker foldenable foldlevel=0
```
![Peek 2020-12-21 12-50](https://user-images.githubusercontent.com/9465658/102778352-b7086900-4392-11eb-948e-f316b483b50d.gif)