### PR TITLE
README and docs: nvim_lsp -> lspconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,10 +188,10 @@ lua << END
 local lsp_status = require('lsp-status')
 lsp_status.register_progress()
 
-local nvim_lsp = require('nvim_lsp')
+local lspconfig = require('lspconfig')
 
 -- Some arbitrary servers
-nvim_lsp.clangd.setup({
+lspconfig.clangd.setup({
   handlers = lsp_status.extensions.clangd.setup(),
   init_options = {
     clangdFileStatus = true
@@ -200,18 +200,18 @@ nvim_lsp.clangd.setup({
   capabilities = lsp_status.capabilities
 })
 
-nvim_lsp.pyls_ms.setup({
+lspconfig.pyls_ms.setup({
   handlers = lsp_status.extensions.pyls_ms.setup(),
   settings = { python = { workspaceSymbols = { enabled = true }}},
   on_attach = lsp_status.on_attach,
   capabilities = lsp_status.capabilities
 })
 
-nvim_lsp.ghcide.setup({
+lspconfig.ghcide.setup({
   on_attach = lsp_status.on_attach,
   capabilities = lsp_status.capabilities
 })
-nvim_lsp.rust_analyzer.setup({
+lspconfig.rust_analyzer.setup({
   on_attach = lsp_status.on_attach,
   capabilities = lsp_status.capabilities
 })

--- a/doc/lsp-status.txt
+++ b/doc/lsp-status.txt
@@ -45,10 +45,10 @@ example:>
   local lsp_status = require('lsp-status')
   lsp_status.register_progress()
 
-  local nvim_lsp = require('nvim_lsp')
+  local lspconfig = require('lspconfig')
 
   -- Some arbitrary servers
-  nvim_lsp.clangd.setup({
+  lspconfig.clangd.setup({
     handlers = lsp_status.extensions.clangd.setup(),
     init_options = {
       clangdFileStatus = true
@@ -57,18 +57,18 @@ example:>
     capabilities = lsp_status.capabilities
   })
 
-  nvim_lsp.pyls_ms.setup({
+  lspconfig.pyls_ms.setup({
     handlers = lsp_status.extensions.pyls_ms.setup(),
     settings = { python = { workspaceSymbols = { enabled = true }}},
     on_attach = lsp_status.on_attach,
     capabilities = lsp_status.capabilities
   })
 
-  nvim_lsp.ghcide.setup({
+  lspconfig.ghcide.setup({
     on_attach = lsp_status.on_attach,
     capabilities = lsp_status.capabilities
   })
-  nvim_lsp.rust_analyzer.setup({
+  lspconfig.rust_analyzer.setup({
     on_attach = lsp_status.on_attach,
     capabilities = lsp_status.capabilities
   })


### PR DESCRIPTION
Currently the README and docs still refers to `lspconfig` as `nvim_lsp`. All this PR does is replace all instances of `nvim_lsp` with `lspconfig`.