### PR TITLE
Always add a space after status_symbol

### DIFF
--- a/lua/lsp-status/statusline.lua
+++ b/lua/lsp-status/statusline.lua
@@ -40,35 +40,26 @@ local function get_lsp_statusline(bufnr)
   if #vim.lsp.buf_get_clients(bufnr) == 0 then return '' end
   local buf_diagnostics = config.diagnostics and diagnostics(bufnr) or nil
   local buf_messages = messages()
-  local only_hint = true
-  local some_diagnostics = false
   local status_parts = {}
   if buf_diagnostics then
     if buf_diagnostics.errors and buf_diagnostics.errors > 0 then
       table.insert(status_parts,
                    config.indicator_errors .. config.indicator_separator .. buf_diagnostics.errors)
-      only_hint = false
-      some_diagnostics = true
     end
 
     if buf_diagnostics.warnings and buf_diagnostics.warnings > 0 then
       table.insert(status_parts, config.indicator_warnings .. config.indicator_separator ..
                      buf_diagnostics.warnings)
-      only_hint = false
-      some_diagnostics = true
     end
 
     if buf_diagnostics.info and buf_diagnostics.info > 0 then
       table.insert(status_parts,
                    config.indicator_info .. config.indicator_separator .. buf_diagnostics.info)
-      only_hint = false
-      some_diagnostics = true
     end
 
     if buf_diagnostics.hints and buf_diagnostics.hints > 0 then
       table.insert(status_parts,
                    config.indicator_hint .. config.indicator_separator .. buf_diagnostics.hints)
-      some_diagnostics = true
     end
   end
 
@@ -105,7 +96,7 @@ local function get_lsp_statusline(bufnr)
   end
 
   local base_status = vim.trim(table.concat(status_parts, ' ') .. ' ' .. table.concat(msgs, ' '))
-  local symbol = config.status_symbol .. ((some_diagnostics and only_hint) and '' or ' ')
+  local symbol = config.status_symbol .. ' '
   if config.current_function then
     local current_function = vim.b.lsp_current_function
     if current_function and current_function ~= '' then


### PR DESCRIPTION
I noticed once I'd set this up that when I only had hints, no space was being added after the status symbol:

![Hint With No Space](https://user-images.githubusercontent.com/13041332/109642165-87bc6800-7b4a-11eb-8b63-111693f4e339.png)

I expected to find when I looked in the code that this was unintentional, but this looks pretty intentional. However, I think this should be considered a bug, because it treats hints differently from the other types of diagnostics.

This change makes the diagnostics when there are only hints...

![Hint With Space](https://user-images.githubusercontent.com/13041332/109642713-3cef2000-7b4b-11eb-9f81-291892170364.png)

...render the same as when there are other types of diagnostics too, e.g. hints and errors:

![Screenshot 2021-03-02 at 11 35 06](https://user-images.githubusercontent.com/13041332/109642803-5728fe00-7b4b-11eb-9bba-c0c8cf8dedd1.png)

