### PR TITLE
Add additional symbol kinds for `current_function`

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ call packager#add('nvim-lua/lsp-status.nvim')
 The plugin provides several utilities:
 ```lua
 update_current_function() -- Set/reset the b:lsp_current_function variable
+-- Shows the current function, method, class, struct, interface, enum, module, or namespace
 diagnostics() -- Return a table with all diagnostic counts for the current buffer
 messages() -- Return a table listing progress and other status messages for display
 register_progress() -- Register the provided handler for progress messages

--- a/doc/lsp-status.txt
+++ b/doc/lsp-status.txt
@@ -103,7 +103,8 @@ config({config})                                   *lsp-status.config()*
                   accepted as the symbol currently containing the cursor.• 
                 • `current_function`: Boolean, `true` if the current function
                   should be updated and displayed in the default statusline
-                  component.
+                  component. Shows the current function, method, class,
+                  struct, interface, enum, module, or namespace.
                 • `indicator_errors` : Symbol to place next to the error count
                   in `status` . Default: '',• 
                 • `indicator_warnings` : Symbol to place next to the warning

--- a/lua/lsp-status/current_function.lua
+++ b/lua/lsp-status/current_function.lua
@@ -9,6 +9,18 @@ local function init(_, config)
   _config = config
 end
 
+-- the symbol kinds which are valid scopes
+local scope_kinds = {
+ 'Class' = true,
+ 'Function' = true,
+ 'Method' = true,
+ 'Struct' = true,
+ 'Enum' = true,
+ 'Interface' = true,
+ 'Namespace' = true,
+ 'Module' = true,
+}
+
 -- Find current function context
 local function current_function_callback(_, _, result, _, _)
   vim.b.lsp_current_function = ''
@@ -18,14 +30,7 @@ local function current_function_callback(_, _, result, _, _)
 
   local function_symbols = util.filter(util.extract_symbols(result),
     function(_, v)
-      return (v.kind == 'Class' or
-              v.kind == 'Function' or 
-              v.kind == 'Method' or 
-              v.kind == 'Struct' or 
-              v.kind == 'Enum' or 
-              v.kind == 'Interface' or
-              v.kind == 'Namespace' or
-              v.kind == 'Module')
+      return scope_kinds[v]
     end)
 
   if not function_symbols or #function_symbols == 0 then

--- a/lua/lsp-status/current_function.lua
+++ b/lua/lsp-status/current_function.lua
@@ -23,7 +23,9 @@ local function current_function_callback(_, _, result, _, _)
               v.kind == 'Method' or 
               v.kind == 'Struct' or 
               v.kind == 'Enum' or 
-              v.kind == 'Interface')
+              v.kind == 'Interface' or
+              v.kind == 'Namespace' or
+              v.kind == 'Module')
     end)
 
   if not function_symbols or #function_symbols == 0 then

--- a/lua/lsp-status/current_function.lua
+++ b/lua/lsp-status/current_function.lua
@@ -30,7 +30,7 @@ local function current_function_callback(_, _, result, _, _)
 
   local function_symbols = util.filter(util.extract_symbols(result),
     function(_, v)
-      return scope_kinds[v]
+      return scope_kinds[v.kind]
     end)
 
   if not function_symbols or #function_symbols == 0 then

--- a/lua/lsp-status/current_function.lua
+++ b/lua/lsp-status/current_function.lua
@@ -11,14 +11,14 @@ end
 
 -- the symbol kinds which are valid scopes
 local scope_kinds = {
- 'Class' = true,
- 'Function' = true,
- 'Method' = true,
- 'Struct' = true,
- 'Enum' = true,
- 'Interface' = true,
- 'Namespace' = true,
- 'Module' = true,
+ Class = true,
+ Function = true,
+ Method = true,
+ Struct = true,
+ Enum = true,
+ Interface = true,
+ Namespace = true,
+ Module = true,
 }
 
 -- Find current function context

--- a/lua/lsp-status/current_function.lua
+++ b/lua/lsp-status/current_function.lua
@@ -18,7 +18,12 @@ local function current_function_callback(_, _, result, _, _)
 
   local function_symbols = util.filter(util.extract_symbols(result),
     function(_, v)
-      return v.kind == 'Class' or v.kind == 'Function' or v.kind == 'Method'
+      return (v.kind == 'Class' or
+              v.kind == 'Function' or 
+              v.kind == 'Method' or 
+              v.kind == 'Struct' or 
+              v.kind == 'Enum' or 
+              v.kind == 'Interface')
     end)
 
   if not function_symbols or #function_symbols == 0 then


### PR DESCRIPTION
Resolves #48.

This is a larger list of symbol kinds than the original issue, but I think it's justified. These kinds all tend to be top-level, which means you wouldn't lose other information by including these.