### PR TITLE
Add the ability to disable diagnostics

### DIFF
--- a/lua/lsp-status.lua
+++ b/lua/lsp-status.lua
@@ -1,6 +1,7 @@
 local default_config = {
   kind_labels = {},
   current_function = true,
+  diagnostics = true,
   indicator_separator = ' ',
   indicator_errors = '',
   indicator_warnings = '',

--- a/lua/lsp-status/statusline.lua
+++ b/lua/lsp-status/statusline.lua
@@ -112,7 +112,8 @@ local function get_lsp_statusline(bufnr)
     end
   end
 
-  if not config.diagnostics or base_status ~= '' then return symbol .. base_status .. ' ' end
+  if base_status ~= '' then return symbol .. base_status .. ' ' end
+  if not config.diagnostics then return symbol end
   return symbol .. config.indicator_ok .. ' '
 end
 

--- a/lua/lsp-status/statusline.lua
+++ b/lua/lsp-status/statusline.lua
@@ -37,36 +37,38 @@ end
 local function get_lsp_statusline(bufnr)
   bufnr = bufnr or 0
   if #vim.lsp.buf_get_clients(bufnr) == 0 then return '' end
-  local buf_diagnostics = diagnostics(bufnr)
+  local buf_diagnostics = (config.diagnostics) and diagnostics(bufnr) or nil
   local buf_messages = messages()
   local only_hint = true
   local some_diagnostics = false
   local status_parts = {}
-  if buf_diagnostics.errors and buf_diagnostics.errors > 0 then
-    table.insert(status_parts,
-                 config.indicator_errors .. config.indicator_separator .. buf_diagnostics.errors)
-    only_hint = false
-    some_diagnostics = true
-  end
+  if buf_diagnostics then
+    if buf_diagnostics.errors and buf_diagnostics.errors > 0 then
+      table.insert(status_parts,
+                   config.indicator_errors .. config.indicator_separator .. buf_diagnostics.errors)
+      only_hint = false
+      some_diagnostics = true
+    end
 
-  if buf_diagnostics.warnings and buf_diagnostics.warnings > 0 then
-    table.insert(status_parts, config.indicator_warnings .. config.indicator_separator ..
-                   buf_diagnostics.warnings)
-    only_hint = false
-    some_diagnostics = true
-  end
+    if buf_diagnostics.warnings and buf_diagnostics.warnings > 0 then
+      table.insert(status_parts, config.indicator_warnings .. config.indicator_separator ..
+                     buf_diagnostics.warnings)
+      only_hint = false
+      some_diagnostics = true
+    end
 
-  if buf_diagnostics.info and buf_diagnostics.info > 0 then
-    table.insert(status_parts,
-                 config.indicator_info .. config.indicator_separator .. buf_diagnostics.info)
-    only_hint = false
-    some_diagnostics = true
-  end
+    if buf_diagnostics.info and buf_diagnostics.info > 0 then
+      table.insert(status_parts,
+                   config.indicator_info .. config.indicator_separator .. buf_diagnostics.info)
+      only_hint = false
+      some_diagnostics = true
+    end
 
-  if buf_diagnostics.hints and buf_diagnostics.hints > 0 then
-    table.insert(status_parts,
-                 config.indicator_hint .. config.indicator_separator .. buf_diagnostics.hints)
-    some_diagnostics = true
+    if buf_diagnostics.hints and buf_diagnostics.hints > 0 then
+      table.insert(status_parts,
+                   config.indicator_hint .. config.indicator_separator .. buf_diagnostics.hints)
+      some_diagnostics = true
+    end
   end
 
   local msgs = {}
@@ -110,7 +112,7 @@ local function get_lsp_statusline(bufnr)
     end
   end
 
-  if base_status ~= '' then return symbol .. base_status .. ' ' end
+  if not config.diagnostics or base_status ~= '' then return symbol .. base_status .. ' ' end
   return symbol .. config.indicator_ok .. ' '
 end
 


### PR DESCRIPTION
This PR adds a `diagnostics` setting that allows you to disable indicators. This can be very useful if the statusline in use already offers a diagnostics display feature. For example, https://github.com/hoob3rt/lualine.nvim allows to display nice colored indicators.