### PR TITLE
fix(get_lsp_statusline): fixed lsp status always return empty string if lsp is restarted

### DIFF
--- a/lua/lsp-status/statusline.lua
+++ b/lua/lsp-status/statusline.lua
@@ -76,7 +76,7 @@ end
 
 local function get_lsp_statusline(bufnr)
   bufnr = bufnr or 0
-  if #vim.lsp.buf_get_clients(bufnr) == 0 then return '' end
+  if vim.tbl_count(vim.lsp.buf_get_clients(bufnr)) == 0 then return '' end
   local buf_diagnostics = config.diagnostics and diagnostics(bufnr) or nil
   local only_hint = true
   local some_diagnostics = false


### PR DESCRIPTION
Apparently `#vim.lsp.buf_get_clients(bufnr) == 0` always returns 0 if lsp is restarted (why? I dunno. I am not an expert in lua).

Using `vim.tbl_count` solved this issue and if lsp is restarted, it will correctly shows again.