### PR TITLE
Fix exception when report message does not have begin

### DIFF
--- a/lua/lsp-status/messaging.lua
+++ b/lua/lsp-status/messaging.lua
@@ -25,10 +25,18 @@ local function progress_callback(_, msg, ctx)
         spinner = 1
       }
     elseif val.kind == 'report' then
-      messages[client_id].progress[msg.token].message = val.message
-      messages[client_id].progress[msg.token].percentage = val.percentage
-      messages[client_id].progress[msg.token].spinner =
-        messages[client_id].progress[msg.token].spinner + 1
+      if messages[client_id].progress[msg.token] == nil then
+        vim.api.nvim_command('echohl WarningMsg')
+        vim.api.nvim_command(
+          'echom "[lsp-status] Received `report` message with no corresponding `begin` from  ' ..
+            clients[client_id] .. '!"')
+        vim.api.nvim_command('echohl None')
+      else
+        messages[client_id].progress[msg.token].message = val.message
+        messages[client_id].progress[msg.token].percentage = val.percentage
+        messages[client_id].progress[msg.token].spinner =
+          messages[client_id].progress[msg.token].spinner + 1
+      end
     elseif val.kind == 'end' then
       if messages[client_id].progress[msg.token] == nil then
         vim.api.nvim_command('echohl WarningMsg')


### PR DESCRIPTION
I am not entirely sure about the root cause. I am using this plugin from `lualine` in order to get diagnostic counts.

I do use sumneko lua-language-server, and whenever I run `PackerCompile`, I believe lua LSP server is restarted, and messages are lost or something like that. I did not spend too much time investigating about the root cause. I just noted that adding this check similar to how it was done in https://github.com/nvim-lua/lsp-status.nvim/issues/6 resolves the issue.

