### PR TITLE
fix exception when attempt to concatenate a nil value

### DIFF
--- a/lua/lsp-status/messaging.lua
+++ b/lua/lsp-status/messaging.lua
@@ -1,9 +1,11 @@
-local util = require('lsp-status/util')
-local redraw = require('lsp-status/redraw')
+local util = require 'lsp-status/util'
+local redraw = require 'lsp-status/redraw'
 
 local clients = {}
 local messages = {}
-local function init(_messages, _) messages = _messages end
+local function init(_messages, _)
+  messages = _messages
+end
 
 -- Unregister stopped clients
 local function unregister_client(id)
@@ -22,22 +24,25 @@ local function progress_callback(_, msg, ctx)
         title = val.title,
         message = val.message,
         percentage = val.percentage,
-        spinner = 1
+        spinner = 1,
       }
     elseif val.kind == 'report' then
       messages[client_id].progress[msg.token].message = val.message
       messages[client_id].progress[msg.token].percentage = val.percentage
-      messages[client_id].progress[msg.token].spinner =
-        messages[client_id].progress[msg.token].spinner + 1
+      messages[client_id].progress[msg.token].spinner = messages[client_id].progress[msg.token].spinner + 1
     elseif val.kind == 'end' then
       if messages[client_id].progress[msg.token] == nil then
-        vim.api.nvim_command('echohl WarningMsg')
+        vim.api.nvim_command 'echohl WarningMsg'
         if clients[client_id] ~= nil then
           vim.api.nvim_command(
-            'echom "[lsp-status] Received `end` message with no corresponding `begin` from  ' ..
-              clients[client_id] .. '!"')
+            'echom "[lsp-status] Received `end` message with no corresponding `begin` from  '
+              .. clients[client_id]
+              .. '!"'
+          )
+        else
+          vim.api.nvim_command 'echom "[lsp-status] Received `end` message with no corresponding `begin` and nil client!'
         end
-        vim.api.nvim_command('echohl None')
+        vim.api.nvim_command 'echohl None'
       else
         messages[client_id].progress[msg.token].message = val.message
         messages[client_id].progress[msg.token].done = true
@@ -45,7 +50,7 @@ local function progress_callback(_, msg, ctx)
       end
     end
   else
-    table.insert(messages[client_id], {content = val, show_once = true, shown = 0})
+    table.insert(messages[client_id], { content = val, show_once = true, shown = 0 })
   end
 
   redraw.redraw()
@@ -67,19 +72,23 @@ local function get_messages()
           message = ctx.message,
           percentage = ctx.percentage,
           progress = true,
-          spinner = ctx.spinner
+          spinner = ctx.spinner,
         })
 
-        if ctx.done then table.insert(progress_remove, {client = client, token = token}) end
+        if ctx.done then
+          table.insert(progress_remove, { client = client, token = token })
+        end
       end
 
       for i, msg in ipairs(data.messages) do
         if msg.show_once then
           msg.shown = msg.shown + 1
-          if msg.shown > 1 then table.insert(msg_remove, {client = client, idx = i}) end
+          if msg.shown > 1 then
+            table.insert(msg_remove, { client = client, idx = i })
+          end
         end
 
-        table.insert(new_messages, {name = data.name, content = msg.content})
+        table.insert(new_messages, { name = data.name, content = msg.content })
       end
 
       if next(data.status) ~= nil then
@@ -87,14 +96,18 @@ local function get_messages()
           name = data.name,
           content = data.status.content,
           uri = data.status.uri,
-          status = true
+          status = true,
         })
       end
     end
   end
 
-  for _, item in ipairs(msg_remove) do table.remove(messages[item.client].messages, item.idx) end
-  for _, item in ipairs(progress_remove) do messages[item.client].progress[item.token] = nil end
+  for _, item in ipairs(msg_remove) do
+    table.remove(messages[item.client].messages, item.idx)
+  end
+  for _, item in ipairs(progress_remove) do
+    messages[item.client].progress[item.token] = nil
+  end
   return new_messages
 end
 
@@ -118,7 +131,7 @@ local M = {
   register_progress = register_progress,
   register_client = register_client,
   _init = init,
-  capabilities = capabilities
+  capabilities = capabilities,
 }
 
 return M

--- a/lua/lsp-status/messaging.lua
+++ b/lua/lsp-status/messaging.lua
@@ -32,9 +32,11 @@ local function progress_callback(_, msg, ctx)
     elseif val.kind == 'end' then
       if messages[client_id].progress[msg.token] == nil then
         vim.api.nvim_command('echohl WarningMsg')
-        vim.api.nvim_command(
-          'echom "[lsp-status] Received `end` message with no corresponding `begin` from  ' ..
-            clients[client_id] .. '!"')
+        if clients[client_id] ~= nil then
+          vim.api.nvim_command(
+            'echom "[lsp-status] Received `end` message with no corresponding `begin` from  ' ..
+              clients[client_id] .. '!"')
+        end
         vim.api.nvim_command('echohl None')
       else
         messages[client_id].progress[msg.token].message = val.message


### PR DESCRIPTION
I'm receiving the stack error by the rust analyzer

```
Error executing vim.schedule lua callback: ...vim/plugged/lsp-status.nvim/lua/lsp-status/messaging.lua:38:
 attempt to concatenate a nil value
stack traceback:
        ...vim/plugged/lsp-status.nvim/lua/lsp-status/messaging.lua:38: in function 'fn'
        ...fig/nvim/plugged/lsp-status.nvim/lua/lsp-status/util.lua:71: in function 'handler'
        ...l/Cellar/neovim/0.7.2/share/nvim/runtime/lua/vim/lsp.lua:796: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```
Other users also received the same error: #79
A simple way to solve these problems in my opinion would be to check if the value is different from the nil.

@tjdevries help us!

Fixes #79 